### PR TITLE
Re-linked reference in README.md to readthedocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ spectra, and radiation temperatures. Functionality is described in [Fiducia's on
 pip install fiducia
 ```
 
-More detailed installation instructions can be found [here](INSTALL.md).
+More detailed installation instructions can be found [here](https://fiducia.readthedocs.io/en/latest/install.html).
 
 
 ## License
-Fiducia is released under a [3-clause BSD license](LICENSE.md).
+Fiducia is released under a [3-clause BSD license](https://fiducia.readthedocs.io/en/latest/license.html).
 
 ## Citing Fiducia
-If you use Fiducia in your work, please follow the best practices for citing Fiducia, which can be found [here](CITATION.md).
+If you use Fiducia in your work, please follow the best practices for citing Fiducia, which can be found [here](https://fiducia.readthedocs.io/en/latest/citing.html).
 
 ## Acknowledgements
 Development of Fiducia was supported by the U.S. Department of Energy, and the NNSA.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,6 +21,7 @@ analysis using Fiducia.
    Examples <auto_examples/index>
    Contributing <contributing>
    Citing <citing>
+   License <license>
 
 .. toctree::
    :maxdepth: 1

--- a/docs/license.rst
+++ b/docs/license.rst
@@ -1,0 +1,42 @@
+ .. _license:
+
+******************************
+Fiducia License (BSD 3-clause)
+******************************
+
+© 2020. Triad National Security, LLC. All rights reserved.
+This program was produced under U.S. Government contract 89233218CNA000001 
+for Los Alamos National Laboratory (LANL), which is operated by Triad National 
+Security, LLC for the U.S. Department of Energy/National Nuclear 
+Security Administration. All rights in the program are reserved by Triad 
+National Security, LLC, and the U.S. Department of Energy/National 
+Nuclear Security Administration. The Government is granted for itself and 
+others acting on its behalf a nonexclusive, paid-up, irrevocable 
+worldwide license in this material to reproduce, prepare derivative 
+works, distribute copies to the public, perform publicly and display 
+publicly, and to permit others to do so.
+
+This program is open source under the BSD-3 License.
+Redistribution and use in source and binary forms, with or without 
+modification, are permitted provided that the following conditions are met:
+    1. Redistributions of source code must retain the above copyright notice, 
+    this list of conditions and the following disclaimer.
+
+    2.Redistributions in binary form must reproduce the above copyright notice, 
+    this list of conditions and the following disclaimer in the documentation 
+    and/or other materials provided with the distribution.
+
+    3.Neither the name of the copyright holder nor the names of its contributors 
+    may be used to endorse or promote products derived from this software 
+    without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE 
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(name='fiducia',
-      version='0.2.1',
+      version='0.2.2',
       description='DANTE data unfolder using cubic-spline algorithm',
       long_description=long_description,
       long_description_content_type='text/markdown',


### PR DESCRIPTION
This way links in pypi.org description are not broken due to relative instead of absolute URL references.